### PR TITLE
netdev: fix device address setting for kernel > 5.15

### DIFF
--- a/netdev.c
+++ b/netdev.c
@@ -818,8 +818,17 @@ static int ccat_eth_init_netdev(struct ccat_eth_priv *priv)
 	int status;
 
 	/* init netdev with MAC and stack callbacks */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	u8 mac_addr[ETH_ALEN];
+
+	if (priv->netdev->addr_len != ETH_ALEN)
+		return -EFAULT;
+	memcpy_fromio(mac_addr, priv->reg.mii + 8, ETH_ALEN);
+	eth_hw_addr_set(priv->netdev, mac_addr);
+#else
 	memcpy_fromio(priv->netdev->dev_addr, priv->reg.mii + 8,
 		      priv->netdev->addr_len);
+#endif
 	priv->netdev->netdev_ops = &ccat_eth_netdev_ops;
 	netif_carrier_off(priv->netdev);
 


### PR DESCRIPTION
An "Incompatible netdev->dev_addr" occurs when using this driver on kernels > 5.15.  For these kernels, eth_hw_addr_set() should be used instead of memcpy(). 

eth_hw_addr_set was introduced on v5.15-rc1
https://github.com/torvalds/linux/commit/48eab831ae8b9f7002a533fa4235eed63ea1f1a3

examples
https://github.com/torvalds/linux/commit/b57ceb19aba7d40403ca985ec565db8db20f4331
https://github.com/torvalds/linux/commit/349f631da4e1bdcb1b4a2a3ee630d689bfe6724d

This change has already been applied upstream in Etherlab:
https://gitlab.com/etherlab.org/ethercat/-/commit/d301cbb992e80218735b81c73d49fec705f91d08

